### PR TITLE
MAGENTO-2302 make plugin compatible with PWA 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- The Plugin is now compatible with PWA 6.1, but incompatible with earlier versions
 
 ## [3.3.1] - 2019-01-10
 ### Added

--- a/src/app/design/frontend/base/default/template/shopgate/cloudapi/customer/account/create/header.phtml
+++ b/src/app/design/frontend/base/default/template/shopgate/cloudapi/customer/account/create/header.phtml
@@ -1,63 +1,22 @@
 <script type="text/javascript">
   function initPipelineCall () {
-    showLoadingScreen()
     window.SGAppConnector.sendPipelineRequest(
       'shopgate.user.loginUser.v1',
       true,
       {'strategy': 'auth_code', 'parameters': {'code': '<?php echo $this->getToken(); ?>'}},
       function (err, serial, output) {
-        var commands = [
-          {
-            'c': 'broadcastEvent',
-            'p': {
-              'event': 'userLoggedIn'
-            }
-          },
-          {
-            'c': 'broadcastEvent',
-            'p': {
-              'event': 'closeNotification'
-            }
+        var command = {
+          'c': 'broadcastEvent',
+          'p': {
+            'event': 'userLoggedIn'
           }
-        ]
-
-        if (<?php echo $this->isShopgateCheckout()
-            ? 'false'
-            : 'true'; ?>) {
-          commands.push(
-            {
-              'c': 'broadcastEvent',
-              'p': {
-                'event': 'closeInAppBrowser',
-                'parameters': [<?php echo $this->getShopgateCallbackData() ?>]
-              }
-            }
-          )
         }
 
-        window.SGAppConnector.sendAppCommands(commands)
+        window.SGAppConnector.sendAppCommand(command)
 
         window.location.href = '<?php echo $this->getCheckoutUrl(); ?>'
       }
     )
-  }
-
-  /**
-   * Showing up the loading screen to tell the customer "something" is happening in the background
-   */
-  function showLoadingScreen () {
-    var command = {
-      'c': 'presentNotification',
-      'p': {
-        presentationType: 'centeredFade',
-        src: 'sgapi:loading_notification',
-        timeout: 10,
-        notificationParams: {
-          fullSize: true
-        }
-      }
-    }
-    window.SGAppConnector.sendAppCommand(command)
   }
 </script>
 


### PR DESCRIPTION
# Pull Request Template

## Description

The Plugin is now compatible with PWA 6.1, but incompatible with earlier versions

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
